### PR TITLE
fix: consumor g might blocked forever once CAS before producer release the lock

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -63,6 +63,8 @@ func (q *Producer[T]) Write(v T) error {
 			return nil
 		}
 		runtime.Gosched()
+                // 防止消费端无限阻塞
+                q.blocks.release()
 		// 再次判断是否已关闭
 		if q.closed() {
 			return ClosedError


### PR DESCRIPTION
当写g速度太快，已经将ringbuffer数据填满，但是读g因为业务操作比较慢，在进入下次block之后，写g由于无法再有机会调用release操作，导致读g的block后无法再被release从而进入无限等待状态。

所以我的解放方法有点粗暴，每次在写g中发现队列已满，主动调用release操作。修改后用https://github.com/bruceshao/lockfree/issues/6
的示例将其中的block策略改成ConditionBlock和ChanBlock都可以顺利执行完成。不修改的话，该示例的读g会进入永远等待无法完成状态。