### PR TITLE
fix: add fail-fast for WriteTimeout()

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -102,7 +102,6 @@ func (q *Producer[T]) WriteTimeout(v T, timeout time.Duration) (uint64, bool, er
 			// 释放，防止消费端阻塞
 			q.blocks.release()
 			// 返回写入成功标识
-			// return next, true, nil
 			return true
 		}
 


### PR DESCRIPTION
## change

1. 写操作内加入 `fail-fast` 模式，先尝试写，不行再轮询 timer 状态. timer 定时器是个重操作，先会插入到四叉堆里，后面还涉及到激活唤醒。
2. 加了一个 `timer.Stop()`，避免 timer 泄露。