### PR TITLE
fix: panic: unaligned 64-bit atomic operation on [32 bit machines]

### DIFF
--- a/sequencer.go
+++ b/sequencer.go
@@ -14,9 +14,9 @@ import (
 // sequencer 序号产生器，维护读和写两个状态，写状态具体由内部游标（cursor）维护。
 // 读取状态由自身维护，变量read即可
 type sequencer struct {
-	wc       *cursor
 	rc       uint64 // 读取游标，因为该值仅会被一个g修改，所以不需要使用cursor
 	capacity uint64
+	wc       *cursor
 }
 
 func newSequencer(capacity int) *sequencer {


### PR DESCRIPTION
修复在32位机器上崩溃的问题，重现步骤：
GOARCH=386 GOOS=linux go test . -trimpath


> panic: unaligned 64-bit atomic operation
> 
> goroutine 15063 [running]:
> runtime/internal/atomic.panicUnaligned()
>         runtime/internal/atomic/unaligned.go:8 +0x2d
> runtime/internal/atomic.Load64(0x8ce210c)
>         runtime/internal/atomic/atomic_386.s:225 +0x10
> github.com/bruceshao/lockfree.(*Producer[...]).Write(0x8ca28e0, 0x1)
>         github.com/bruceshao/lockfree/producer.go:58 +0x9e
> github.com/bruceshao/lockfree.TestChanBlockStrategy.func1()
>         github.com/bruceshao/lockfree/lockfree_test.go:64 +0x96
> created by github.com/bruceshao/lockfree.TestChanBlockStrategy
>         github.com/bruceshao/lockfree/lockfree_test.go:61 +0x130
> panic: unaligned 64-bit atomic operation
> 
> goroutine 15061 [running]:
> runtime/internal/atomic.panicUnaligned()
>         runtime/internal/atomic/unaligned.go:8 +0x2d
> runtime/internal/atomic.Load64(0x8ce210c)
>         runtime/internal/atomic/atomic_386.s:225 +0x10
> github.com/bruceshao/lockfree.(*Producer[...]).Write(0x8ca28e0, 0x2)
>         github.com/bruceshao/lockfree/producer.go:58 +0x9e
> github.com/bruceshao/lockfree.TestChanBlockStrategy.func1()
>         github.com/bruceshao/lockfree/lockfree_test.go:64 +0x96
> created by github.com/bruceshao/lockfree.TestChanBlockStrategy
>         github.com/bruceshao/lockfree/lockfree_test.go:61 +0x130