### PR TITLE
Using atomic.Uint64 instead of uint64 to fix unaligned problem

### DIFF
--- a/blocks.go
+++ b/blocks.go
@@ -17,7 +17,7 @@ import (
 // blockStrategy 阻塞策略
 type blockStrategy interface {
 	// block 阻塞
-	block(actual *uint64, expected uint64)
+	block(actual *atomic.Uint64, expected uint64)
 
 	// release 释放阻塞
 	release()
@@ -28,7 +28,7 @@ type blockStrategy interface {
 type SchedBlockStrategy struct {
 }
 
-func (s *SchedBlockStrategy) block(actual *uint64, expected uint64) {
+func (s *SchedBlockStrategy) block(actual *atomic.Uint64, expected uint64) {
 	runtime.Gosched()
 }
 
@@ -51,7 +51,7 @@ func NewSleepBlockStrategy(wait time.Duration) *SleepBlockStrategy {
 	}
 }
 
-func (s *SleepBlockStrategy) block(actual *uint64, expected uint64) {
+func (s *SleepBlockStrategy) block(actual *atomic.Uint64, expected uint64) {
 	time.Sleep(s.t)
 }
 
@@ -69,7 +69,7 @@ func NewProcYieldBlockStrategy(cycle uint32) *ProcYieldBlockStrategy {
 	}
 }
 
-func (s *ProcYieldBlockStrategy) block(actual *uint64, expected uint64) {
+func (s *ProcYieldBlockStrategy) block(actual *atomic.Uint64, expected uint64) {
 	procyield(s.cycle)
 }
 
@@ -84,7 +84,7 @@ func NewOSYieldWaitStrategy() *OSYieldBlockStrategy {
 	return &OSYieldBlockStrategy{}
 }
 
-func (s *OSYieldBlockStrategy) block(actual *uint64, expected uint64) {
+func (s *OSYieldBlockStrategy) block(actual *atomic.Uint64, expected uint64) {
 	osyield()
 }
 
@@ -103,11 +103,11 @@ func NewChanBlockStrategy() *ChanBlockStrategy {
 	}
 }
 
-func (s *ChanBlockStrategy) block(actual *uint64, expected uint64) {
+func (s *ChanBlockStrategy) block(actual *atomic.Uint64, expected uint64) {
 	// 0：未阻塞；1：阻塞
 	if atomic.CompareAndSwapUint32(&s.b, 0, 1) {
 		// 设置成功的话，表示阻塞，需要进行二次判断
-		if atomic.LoadUint64(actual) == expected {
+		if actual.Load() == expected {
 			// 表示阻塞失败，因为结果是一致的，此处需要重新将状态调整回来
 			if atomic.CompareAndSwapUint32(&s.b, 1, 0) {
 				// 表示回调成功，直接退出即可
@@ -144,10 +144,10 @@ func NewConditionBlockStrategy() *ConditionBlockStrategy {
 	}
 }
 
-func (s *ConditionBlockStrategy) block(actual *uint64, expected uint64) {
+func (s *ConditionBlockStrategy) block(actual *atomic.Uint64, expected uint64) {
 	s.cond.L.Lock()
 	defer s.cond.L.Unlock()
-	if atomic.LoadUint64(actual) == expected {
+	if actual.Load() == expected {
 		return
 	}
 	s.cond.Wait()

--- a/buffer.go
+++ b/buffer.go
@@ -37,8 +37,8 @@ func (r *ringBuffer[T]) write(c uint64, v T) {
 	x.c.Store(c+1)
 }
 
-func (r *ringBuffer[T]) element(c uint64) e[T] {
-	return r.buf[c&r.capMask]
+func (r *ringBuffer[T]) element(c uint64) *e[T] {
+	return &r.buf[c&r.capMask]
 }
 
 func (r *ringBuffer[T]) contains(c uint64) (T, *atomic.Uint64, bool) {

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -62,3 +62,18 @@ func TestBuffer(t *testing.T) {
 	x = buf.element(1024)
 	fmt.Println(x)
 }
+
+func TestBufferAlign32(t *testing.T) {
+	buf := newRingBuffer[uint32](1024)
+	buf.write(0, 1)
+	x := buf.element(0)
+	fmt.Println(x)
+
+	buf.write(1023, 2)
+	x = buf.element(1023)
+	fmt.Println(x)
+
+	buf.write(1024, 3)
+	x = buf.element(1024)
+	fmt.Println(x)
+}


### PR DESCRIPTION
在buffer实现中还存在一处unaligned问题，因为使用了泛型，如果泛型本身不是64位对齐的话，比如uint32，会导致对buf中第二个项目的atomic操作时出现对齐问题。所以使用了atomic.Uint64 取代了  uint64实现，因为golang文档中明确说明：

> On ARM, 386, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically via the primitive atomic functions (types [Int64](https://pkg.go.dev/sync/atomic#Int64) and [Uint64](https://pkg.go.dev/sync/atomic#Uint64) are automatically aligned).

来源https://pkg.go.dev/sync/atomic#pkg-note-BUG