### PR TITLE
feat: add batch event mode for consumer

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -21,15 +21,17 @@ type consumer[T any] struct {
 	seqer  *sequencer
 	blocks blockStrategy
 	hdl    EventHandler[T]
+	batch  int
 }
 
-func newConsumer[T any](rbuf *ringBuffer[T], hdl EventHandler[T], sequer *sequencer, blocks blockStrategy) *consumer[T] {
+func newConsumer[T any](batch int, rbuf *ringBuffer[T], hdl EventHandler[T], sequer *sequencer, blocks blockStrategy) *consumer[T] {
 	return &consumer[T]{
 		rbuf:   rbuf,
 		seqer:  sequer,
 		hdl:    hdl,
 		blocks: blocks,
 		status: READY,
+		batch:  batch,
 	}
 }
 
@@ -44,6 +46,12 @@ func (c *consumer[T]) start() error {
 func (c *consumer[T]) handle() {
 	// 判断是否可以获取到
 	rc := c.seqer.nextRead()
+	var count int
+	var items []T
+	if c.batch > 1 {
+		// 提前分配好内存，避免后续循环中动态分配
+		items = make([]T, c.batch)
+	}
 	for {
 		if c.closed() {
 			return
@@ -56,10 +64,25 @@ func (c *consumer[T]) handle() {
 			// 看下读取位置的seq是否OK
 			if v, p, exist := c.rbuf.contains(rc - 1); exist {
 				rc = c.seqer.readIncrement()
-				c.hdl.OnEvent(v)
+				if c.batch <= 1 {
+					c.hdl.OnEvent(v)
+				} else {
+					items[count] = v
+					count++
+					if count >= c.batch {
+						// 批处理数组已满，开始处理数据
+						c.hdl.OnBatchEvent(items[:count])
+						count = 0
+					}
+				}
 				i = 0
 				break
 			} else {
+				// 阻塞前处理掉所有可用的数据
+				if count > 0 {
+					c.hdl.OnBatchEvent(items[:count])
+					count = 0
+				}
 				if i < spin {
 					procyield(30)
 				} else if i < spin+passiveSpin {

--- a/example/perfect/main.go
+++ b/example/perfect/main.go
@@ -21,6 +21,7 @@ var (
 	goSize      = 10000
 	sizePerGo   = 10000
 	cap         = 1024 * 1024
+	batch       = 0
 	timeAnalyse = false
 )
 
@@ -88,7 +89,7 @@ func lockfreeMain() {
 	// 创建事件处理器
 	eh := &longEventHandler[uint64]{}
 	// 创建消费端串行处理的Lockfree
-	lf := lockfree.NewLockfree[uint64](cap, eh, lockfree.NewSleepBlockStrategy(time.Millisecond))
+	lf := lockfree.NewLockfree[uint64](cap, batch, eh, lockfree.NewSleepBlockStrategy(time.Millisecond))
 	// 启动Lockfree
 	if err := lf.Start(); err != nil {
 		panic(err)
@@ -246,5 +247,11 @@ type longEventHandler[T uint64] struct {
 func (h *longEventHandler[T]) OnEvent(v uint64) {
 	if v%10000000 == 0 {
 		fmt.Println("lockfree [", v, "]")
+	}
+}
+
+func (h *longEventHandler[T]) OnBatchEvent(v []uint64) {
+	for i := range v {
+		h.OnEvent(v[i])
 	}
 }

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -36,6 +36,7 @@ func main() {
 	// 创建消费端串行处理的Lockfree
 	lf := lockfree.NewLockfree[uint64](
 		1024*1024,
+		0,
 		handler,
 		lockfree.NewSleepBlockStrategy(time.Millisecond),
 	)
@@ -91,6 +92,12 @@ func (h *eventHandler[T]) OnEvent(v uint64) {
 
 	if cur%10000000 == 0 {
 		fmt.Printf("eventHandler consume %v\n", cur)
+	}
+}
+
+func (h *eventHandler[T]) OnBatchEvent(v []uint64) {
+	for i := range v {
+		h.OnEvent(v[i])
 	}
 }
 

--- a/handler.go
+++ b/handler.go
@@ -13,4 +13,6 @@ package lockfree
 type EventHandler[T any] interface {
 	// OnEvent 用户侧实现，事件处理方法
 	OnEvent(t T)
+        // OnBatchEvent 用户测试先，事件批处理方法
+        OnBatchEvent(t []T)
 }

--- a/lockfree.go
+++ b/lockfree.go
@@ -23,12 +23,12 @@ type Lockfree[T any] struct {
 // capacity：buffer的容量大小，类似于chan的大小，但要求必须是2^n，即2的指数倍，如果不是的话会被修改
 // handler：消费端的事件处理器
 // blocks：读取阻塞时的处理策略
-func NewLockfree[T any](capacity int, handler EventHandler[T], blocks blockStrategy) *Lockfree[T] {
+func NewLockfree[T any](capacity, batch int, handler EventHandler[T], blocks blockStrategy) *Lockfree[T] {
 	// 重新计算正确的容量
 	capacity = minSuitableCap(capacity)
 	seqer := newSequencer(capacity)
 	rbuf := newRingBuffer[T](capacity)
-	cmer := newConsumer[T](rbuf, handler, seqer, blocks)
+	cmer := newConsumer[T](batch, rbuf, handler, seqer, blocks)
 	writer := newProducer[T](seqer, rbuf, blocks)
 	return &Lockfree[T]{
 		writer:   writer,

--- a/lockfree.go
+++ b/lockfree.go
@@ -21,6 +21,7 @@ type Lockfree[T any] struct {
 
 // NewLockfree 自定义创建消费端的Disruptor
 // capacity：buffer的容量大小，类似于chan的大小，但要求必须是2^n，即2的指数倍，如果不是的话会被修改
+// batch: 如果batch值大于1，表示启用批处理模式，消费端会一次处理尽可能多的数据，最多batch个数据
 // handler：消费端的事件处理器
 // blocks：读取阻塞时的处理策略
 func NewLockfree[T any](capacity, batch int, handler EventHandler[T], blocks blockStrategy) *Lockfree[T] {

--- a/lockfree_test.go
+++ b/lockfree_test.go
@@ -19,7 +19,38 @@ func BenchmarkLockFree(b *testing.B) {
 		counter = uint64(0)
 	)
 	eh := &longEventHandler[uint64]{}
-	disruptor := NewLockfree[uint64](1024*1024, eh, &SleepBlockStrategy{
+	disruptor := NewLockfree[uint64](1024*1024, 0, eh, &SleepBlockStrategy{
+		t: time.Microsecond,
+	})
+	disruptor.Start()
+	producer := disruptor.Producer()
+	var wg sync.WaitGroup
+	wg.Add(b.N)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		go func() {
+			for j := 0; j < SchPerGo; j++ {
+				x := atomic.AddUint64(&counter, 1)
+				err := producer.Write(x)
+				if err != nil {
+					panic(err)
+				}
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	b.StopTimer()
+	time.Sleep(time.Second * 1)
+	disruptor.Close()
+}
+
+func BenchmarkLockFreeBatch(b *testing.B) {
+	var (
+		counter = uint64(0)
+	)
+	eh := &longEventHandler[uint64]{}
+	disruptor := NewLockfree[uint64](1024*1024, 128, eh, &SleepBlockStrategy{
 		t: time.Microsecond,
 	})
 	disruptor.Start()
@@ -48,11 +79,11 @@ func BenchmarkLockFree(b *testing.B) {
 func TestChanBlockStrategy(t *testing.T) {
 	var (
 		counter = uint64(0)
-		goS = 1000
-		perGo = 100
+		goS     = 1000
+		perGo   = 100
 	)
 	eh := &longEventHandler[uint64]{}
-	disruptor := NewLockfree[uint64](2, eh, NewChanBlockStrategy())
+	disruptor := NewLockfree[uint64](2, 0, eh, NewChanBlockStrategy())
 	disruptor.Start()
 	producer := disruptor.Producer()
 	var wg sync.WaitGroup
@@ -77,11 +108,11 @@ func TestChanBlockStrategy(t *testing.T) {
 func TestCondBlockStrategy(t *testing.T) {
 	var (
 		counter = uint64(0)
-		goS = 1000
-		perGo = 100
+		goS     = 1000
+		perGo   = 100
 	)
 	eh := &longEventHandler[uint64]{}
-	disruptor := NewLockfree[uint64](2, eh, NewConditionBlockStrategy())
+	disruptor := NewLockfree[uint64](2, 0, eh, NewConditionBlockStrategy())
 	disruptor.Start()
 	producer := disruptor.Producer()
 	var wg sync.WaitGroup


### PR DESCRIPTION
增加批处理事件处理功能，主要从以下两点出发：
1. 某些业务处理确实需要批处理模式，一个典型的网络应用案例是linux下udp的ReadBatch和WriteBatch操作，https://pkg.go.dev/golang.org/x/net/ipv4#PacketConn.WriteBatch
使用批处理后，能显著降低系统调用syscall的频率，比如使用golang.org/x/ipv4的WriteBatch能比普通的udp在一次syscall中处理更多的网络数据。
3. 尽可能的在读g一次操作中处理更多的数据，从而节约在阻塞中的开销，可以显著降低延时，节约不必要的阻塞操作

> $ go test . -bench=BenchmarkLockFree -run=BenchmarkLockFree -benchmem
> goos: linux
> goarch: amd64
> pkg: github.com/bruceshao/lockfree
> cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
> BenchmarkLockFree-8                 3352            526717 ns/op             482 B/op          1 allocs/op
> BenchmarkLockFreeBatch-8            3855            455707 ns/op             100 B/op          1 allocs/op
> PASS
> ok      github.com/bruceshao/lockfree   9.615s

可以看到使用批处理方式的响应时间会比单事件模式响应时间ns/op缩短10%以上。