### PR TITLE
fix: using uint64 pointer to fix unalign problem for x86 platform

### DIFF
--- a/buffer_test.go
+++ b/buffer_test.go
@@ -49,7 +49,7 @@ func TestX(t *testing.T) {
 }
 
 func TestBuffer(t *testing.T) {
-	buf := newRingBuffer[uint64](1024)
+	buf := newRingBuffer[uint8](1024)
 	buf.write(0, 1)
 	x := buf.element(0)
 	fmt.Println(x)


### PR DESCRIPTION
使用uint64指针而不是取值方式来解决32位系统上的对齐问题，避免因为使用go 1.19才引入的atomic.Uint64提供向下兼容性支持。见 https://github.com/bruceshao/lockfree/pull/21